### PR TITLE
Fix absolute imports

### DIFF
--- a/Simulation/ctrl.py
+++ b/Simulation/ctrl.py
@@ -16,8 +16,8 @@ import numpy as np
 from numpy import pi
 from numpy import sin, cos, tan, sqrt
 from numpy.linalg import norm
-import utils
-import config
+
+from . import utils, config
 
 rad2deg = 180.0/pi
 deg2rad = pi/180.0

--- a/Simulation/quadFiles/initQuad.py
+++ b/Simulation/quadFiles/initQuad.py
@@ -9,8 +9,8 @@ Please feel free to use and modify this, but keep the above information. Thanks!
 import numpy as np
 from numpy import pi
 from numpy.linalg import inv
-import utils
-import config
+
+from .. import utils, config
 
 
 def sys_params():

--- a/Simulation/quadFiles/quad.py
+++ b/Simulation/quadFiles/quad.py
@@ -1,17 +1,15 @@
 
 
 import numpy as np
+import pandas as pd
 from numpy import sin, cos, tan, pi, sign
 from scipy.integrate import ode
 
-from quadFiles.initQuad import sys_params, init_cmd, init_state
-from utils.EKF import EKF_IMU
-from utils import stateConversions as sC
-from utils import rotationConversion as rC
-import pandas as pd
-import utils
-import config
-import pdb
+from .. import utils, config
+from ..utils.EKF import EKF_IMU
+from ..utils import stateConversions as sC
+from ..utils import rotationConversion as rC
+from .initQuad import sys_params, init_cmd, init_state
 
 deg2rad = pi/180.0
 # Global variables for Kalman Filter

--- a/Simulation/run_3D_simulation.py
+++ b/Simulation/run_3D_simulation.py
@@ -11,13 +11,12 @@ import matplotlib.pyplot as plt
 import time
 import cProfile
 
-from trajectory import Trajectory
-from ctrl import Control
-from quadFiles.quad import Quadcopter
-from utils.windModel import Wind
-import utils
-import config
-from utils.EKF import EKF_IMU
+from . import utils, config
+from .ctrl import Control
+from .trajectory import Trajectory
+from .quadFiles.quad import Quadcopter
+from .utils.windModel import Wind
+from .utils.EKF import EKF_IMU
 
 def quad_sim(t, Ts, quad, ctrl, wind, traj):
     

--- a/Simulation/trajectory.py
+++ b/Simulation/trajectory.py
@@ -17,8 +17,10 @@ Please feel free to use and modify this, but keep the above information. Thanks!
 import numpy as np
 from numpy import pi
 from numpy.linalg import norm
-from waypoints import makeWaypoints
-import config
+
+from . import config
+from .waypoints import makeWaypoints
+
 
 class Trajectory:
 

--- a/Simulation/utils/animation.py
+++ b/Simulation/utils/animation.py
@@ -12,8 +12,7 @@ import matplotlib.pyplot as plt
 import mpl_toolkits.mplot3d.axes3d as p3
 from matplotlib import animation
 
-import utils
-import config
+from .. import utils, config
 
 numFrames = 8
 

--- a/Simulation/utils/display.py
+++ b/Simulation/utils/display.py
@@ -9,7 +9,8 @@ Please feel free to use and modify this, but keep the above information. Thanks!
 import numpy as np
 from numpy import pi
 import matplotlib.pyplot as plt
-import utils
+
+from . import rotationConversion as rotConv
 
 rad2deg = 180.0/pi
 deg2rad = pi/180.0
@@ -89,7 +90,7 @@ def makeFigures(params, time, pos_all, vel_all, quat_all, omega_all, euler_all, 
     thetaDes = np.zeros(q0Des.shape[0])
     phiDes   = np.zeros(q0Des.shape[0])
     for ii in range(q0Des.shape[0]):
-        YPR = utils.quatToYPR_ZYX(sDes_calc[ii,9:13])
+        YPR = rotConv.quatToYPR_ZYX(sDes_calc[ii,9:13])
         psiDes[ii]   = YPR[0]*rad2deg
         thetaDes[ii] = YPR[1]*rad2deg
         phiDes[ii]   = YPR[2]*rad2deg

--- a/Simulation/utils/mixer.py
+++ b/Simulation/utils/mixer.py
@@ -7,7 +7,8 @@ Please feel free to use and modify this, but keep the above information. Thanks!
 """
 
 import numpy as np
-import config
+
+from .. import config
 
 
 def mixerFM(quad, thr, moment):

--- a/Simulation/utils/windModel.py
+++ b/Simulation/utils/windModel.py
@@ -9,7 +9,8 @@ Please feel free to use and modify this, but keep the above information. Thanks!
 import numpy as np
 from numpy import sin, cos, pi
 import random as rd
-import config
+
+from .. import config
 
 deg2rad = pi/180.0
 

--- a/Simulation/waypoints.py
+++ b/Simulation/waypoints.py
@@ -8,7 +8,8 @@ Please feel free to use and modify this, but keep the above information. Thanks!
 
 import numpy as np
 from numpy import pi
-import config
+
+from . import config
 
 deg2rad = pi/180.0
 

--- a/run_3D_simulation.py
+++ b/run_3D_simulation.py
@@ -11,12 +11,12 @@ import matplotlib.pyplot as plt
 import time
 import cProfile
 
-from . import utils, config
-from .ctrl import Control
-from .trajectory import Trajectory
-from .quadFiles.quad import Quadcopter
-from .utils.windModel import Wind
-from .utils.EKF import EKF_IMU
+from Simulation import utils, config
+from Simulation.ctrl import Control
+from Simulation.trajectory import Trajectory
+from Simulation.quadFiles.quad import Quadcopter
+from Simulation.utils.windModel import Wind
+from Simulation.utils.EKF import EKF_IMU
 
 def quad_sim(t, Ts, quad, ctrl, wind, traj):
     


### PR DESCRIPTION
Close #2 

Transform `Simulation` directory into Python module and make all imports module-relative to support using project as Python library. Relative imports allow relocation/installation of the module without requiring modifications to the Python path.